### PR TITLE
updates to create sep17 baseline

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,6 @@
 [cime]
-tag = 910960cfe
+tag = 47b6300
+
 protocol = git
 repo_url = https://github.com/ESMCI/cime.git
 local_path = cime
@@ -7,9 +8,9 @@ externals = ../Externals_cime.cfg
 required = True
 
 [cam]
-tag = nuopc_cap_n32_cam6_1_008/components/cam
+tag = nuopc_cap_n35_cam6_1_030/components/cam
 protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/branch_tags/nuopc_cap_tags
+repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/branch_tags/nuopc_cap_tags/
 local_path = components/cam
 required = True
 
@@ -44,7 +45,7 @@ local_path = components/mosart
 required = True
 
 [fms]
-tag = 3b8096b
+tag = fi_20190820
 protocol = git
 repo_url = https://github.com/ESCOMP/FMS_interface
 local_path = libraries/FMS
@@ -59,7 +60,7 @@ local_path = libraries/CVMix
 required = True
 
 [mom]
-tag = 7e54197
+tag = mi_20190821
 protocol = git
 repo_url = https://github.com/ESCOMP/MOM_interface
 local_path = components/mom

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -1,5 +1,5 @@
 [cmeps]
-tag = 471ac52
+tag = 08a1eea
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = src/drivers/nuopc/


### PR DESCRIPTION
This is the latest UFSCOMP set and was used to create the baselines in 
/glade/p/cesmdata/cseg/nuopc_baselines/sep17

The following baseline comparisons to sep11 fail
```
    FAIL ERR_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io BASELINE sep11: DIFF
    FAIL ERS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel BASELINE sep11: DIFF
    FAIL ERS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel BASELINE sep11: DIFF
    FAIL ERS_Vnuopc_Ln5.ne16_ne16_mg17.QPC4.cheyenne_intel.cam-nuopc_cap BASELINE sep11: DIFF
    FAIL SMS_Vnuopc_Ld3.f09_f09_mg17.A1850DLND.cheyenne_intel BASELINE sep11: DIFF
    FAIL SMS_Vnuopc_Ld5.f19_g16.BMOM.cheyenne_intel.allactive-nuopc_cap_io BASELINE sep11: DIFF
    FAIL SMS_Vnuopc_Ld5.T62_g16.CMOM.cheyenne_intel BASELINE sep11: DIFF
    FAIL SMS_Vnuopc_Ld5.T62_g16.GMOM.cheyenne_intel BASELINE sep11: DIFF
    FAIL SMS_Vnuopc_Ln5.f19_f19_mg17.F2000Nuopc.cheyenne_intel.cam-nuopc_cap BASELINE sep11: DIFF
    FAIL SMS_Vnuopc_Ln5.ne16_ne16_mg17.QPC4.cheyenne_intel.cam-nuopc_cap BASELINE sep11: DIFF
```
The MOM cases differ due to a change in OCN_NCPL and in CPL_ALBAV (Was FALSE, now TRUE)
The QPC4 case differs due to changes in cam se dycore subcylcling.
The F2000 case had a change in topo file. 

The A1850DLND cases differ due to a change in the exchange field count.
